### PR TITLE
Initial Proof of Concept for debugging of Child Processes

### DIFF
--- a/lib/ewd.js
+++ b/lib/ewd.js
@@ -297,7 +297,20 @@ var ewd = {
       i = null;
     }
   },
+  nextDebugPort: 5860,
   startChildProcess: function(processNo) {
+    // Debugging support
+    var debug = true;
+    if(debug) {
+      for (var pid in ewd.process) {
+        if (ewd.process[pid].debugPort !== '') {
+          if (ewd.process[pid].debugPort > this.nextDebugPort) {
+            this.nextDebugPort = ewd.process[pid].debugPort++;
+          }
+        }
+      }
+      process.execArgv.push('--debug=' + this.nextDebugPort);
+    }
     var childProcess = cp.fork(this.childProcessPath, [], {env: process.env});
     var pid = childProcess.pid;
     ewd.process[pid] = childProcess;
@@ -307,6 +320,8 @@ var ewd = {
     this.requestsByProcess[pid] = 0;
     thisProcess.processNo = processNo;
     this.queueByPid[pid] = [];
+    thisProcess.debugPort = this.nextDebugPort;
+    this.nextDebugPort++;
 
     thisProcess.on('message', function(response) {
       response.processNo = processNo;
@@ -326,7 +341,7 @@ var ewd = {
           //ewd.log('process ' + pid + ' returned to available pool', 3);
           ewd.process[pid].isAvailable = true;
           ewd.queueEvent.emit("processQueue");
-          ewd.sendToMonitor({type: 'pidUpdate', pid: pid, noOfRequests: ewd.requestsByProcess[pid], available: ewd.process[pid].isAvailable});
+          ewd.sendToMonitor({type: 'pidUpdate', pid: pid, noOfRequests: ewd.requestsByProcess[pid], available: ewd.process[pid].isAvailable, debugPort: ewd.process[pid].debugPort});
         }
       }
       response = null;
@@ -340,7 +355,7 @@ var ewd = {
     var pid;
     var pids = [];
     for (pid in ewd.process) {
-      pids.push({pid: pid, available: ewd.process[pid].isAvailable, noOfRequests: ewd.requestsByProcess[pid]})
+      pids.push({pid: pid, available: ewd.process[pid].isAvailable, noOfRequests: ewd.requestsByProcess[pid], debugPort: ewd.process[pid].debugPort})
     }
     pid = null;
     return pids;
@@ -754,7 +769,7 @@ var ewd = {
         if (ewd.process[pid].isAvailable) {
           queuedRequest = ewd.queueByPid[pid].shift();
           ewd.process[pid].isAvailable = false;
-          ewd.sendToMonitor({type: 'pidUpdate', pid: pid, noOfRequests: ewd.requestsByProcess[pid], available: ewd.process[pid].isAvailable});
+          ewd.sendToMonitor({type: 'pidUpdate', pid: pid, noOfRequests: ewd.requestsByProcess[pid], available: ewd.process[pid].isAvailable, debugPort: ewd.process[pid].debugPort});
           ewd.sendRequestToChildProcess(queuedRequest, pid);
         }
       }
@@ -806,7 +821,7 @@ var ewd = {
     childProcess.send(queuedRequest);
 
     ewd.requestsByProcess[pid]++;
-    ewd.sendToMonitor({type: 'pidUpdate', pid: pid, noOfRequests: ewd.requestsByProcess[pid], available: ewd.process[pid].isAvailable});
+    ewd.sendToMonitor({type: 'pidUpdate', pid: pid, noOfRequests: ewd.requestsByProcess[pid], available: ewd.process[pid].isAvailable, debugPort: ewd.process[pid].debugPort});
     childProcess = null;
     type = null;
   },
@@ -817,7 +832,7 @@ var ewd = {
     for (pid in ewd.process) {
       if (ewd.process[pid].isAvailable) {
         ewd.process[pid].isAvailable = false;
-        ewd.sendToMonitor({type: 'pidUpdate', pid: pid, noOfRequests: ewd.requestsByProcess[pid], available: ewd.process[pid].isAvailable});
+        ewd.sendToMonitor({type: 'pidUpdate', pid: pid, noOfRequests: ewd.requestsByProcess[pid], available: ewd.process[pid].isAvailable, debugPort: ewd.process[pid].debugPort});
         return pid;
       }
     }
@@ -1255,7 +1270,8 @@ var ewd = {
         procObj[pid] = {
           processNo: proc.processNo,
           isAvailable: proc.isAvailable,
-          started: proc.started
+          started: proc.started,
+          debugPort: proc.debugPort
         }
       }
       var messageObj = {

--- a/www/ewd/ewdMonitor/app.js
+++ b/www/ewd/ewdMonitor/app.js
@@ -93,6 +93,7 @@ EWD.application = {
       html = html + '<td class="cpPid" id="cpPid' + pid + '">' + pid + '</td>';
       html = html + '<td id="cpRequests' + pid + '">0</td>';
       html = html + '<td id="cpAvailable' + pid + '">true</td>';
+      html = html + '<td id="cpDebugPort">Please refresh<td>';
       //html = html + '<td><button class="btn btn-danger pull-right cpStop" type="button" id="cpStopBtn' + pid + '">Stop</button></td>';
       html = html + '<td><button class="btn btn-danger pull-right cpStop" type="button" id="cpStopBtn' + pid + '" data-toggle="tooltip" data-placement="top" title="" data-original-title="Stop Child Process"><span class="glyphicon glyphicon-remove"></span></button></td>';
       html = html + '</tr>';
@@ -148,6 +149,13 @@ EWD.application = {
           toastr.clear();
           toastr.warning('At least one Child Process must be left running');
         }
+      });
+      $('.cpDebug').unbind('click');
+      $('.cpDebug').on('click', function(e) {
+        var id = e.target.id;
+        if (!id) id = e.target.parentNode.id;
+        var port = id.split('cpDebug')[1];
+        window.open('http://' + window.location.hostname + ':8181/debug?port=' + port, '_blank');
       });
     };
 
@@ -1266,6 +1274,12 @@ EWD.application = {
           html = html + '<td class="cpPid" id="cpPid' + pid + '">' + pid + '</td>';
           html = html + '<td id="cpRequests' + pid + '">' + childProcess.noOfRequests + '</td>';
           html = html + '<td id="cpAvailable' + pid + '">' + childProcess.available + '</td>';
+          if (childProcess.debugPort !=='') {
+            html = html + '<td id="cpDebugPort' + childProcess.debugPort + '"><button class="btn btn-warning pull-right cpDebug" type="button" id="cpDebug' + childProcess.debugPort +'"><span class="glyphicon glyphicon-wrench"></span></td>';
+          }
+          else {
+            html = html + '<td id="cpDebugPort">&nbsp</td>';
+          }
           //html = html + '<td><button class="btn btn-danger pull-right cpStop" type="button" id="cpStopBtn' + pid + '">Stop</button></td>';
           html = html + '<td><button class="btn btn-danger pull-right cpStop" type="button" id="cpStopBtn' + pid + '" data-toggle="tooltip" data-placement="top" title="" data-original-title="Stop Child Process"><span class="glyphicon glyphicon-remove"></span></button></td>';
           html = html + '</tr>';

--- a/www/ewd/ewdMonitor/index.html
+++ b/www/ewd/ewdMonitor/index.html
@@ -252,6 +252,7 @@
                             <th>PID</th>
                             <th>Requests</th>
                             <th>Available</th>
+                            <th>Debug</th>
                             <th>
                               <button class="btn btn-success pull-right" type="button" id="cpStartBtn" data-toggle="tooltip" data-placement="top" title="" data-original-title="Start a new Child Process">
                                 <span class="glyphicon glyphicon-off"></span>


### PR DESCRIPTION
Current code has debug always turned on for worker (child) processes.
This is controlled by the debug flag in lib/ewd.js

Enhanced ewdMonitor's app.js and index.html to display a debug button
linked to a local instance of node-inspector (running on port 8181). Any
new child processes created via the interface don't show up correctly
until a full refresh is performed due to the passing of only the pid to
the function and no obvious access to the underlying data structure.
