### PR TITLE
Added debug option on startup

### DIFF
--- a/lib/ewd.js
+++ b/lib/ewd.js
@@ -79,6 +79,7 @@ var ewd = {
         type: 'gtm',
       },
       debug: {
+				enabled: false,
         child_port: 5859,
         web_port: 8081
       },
@@ -128,6 +129,12 @@ var ewd = {
       }
     };
 
+    if (params && params.debug && typeof params.debug.enabled !== 'undefined') {
+      defaults.debug.enabled = params.debug.enabled;
+      if (params.debug.enabled)
+        params.poolSize = 1;
+    };
+
     if (params && params.database && typeof params.database.type !== 'undefined') defaults.database.type = params.database.type;
     if (params && typeof params.os !== 'undefined') defaults.os = params.os;
     if (defaults.database.type === 'cache' || defaults.database.type === 'globals') {
@@ -166,9 +173,11 @@ var ewd = {
     var value;
     var subDefaults = {
       database: '',
+      debug: '',
       https: '',
       webSockets: '',
       management: '',
+      ajax: '',
       webRTC: '',
     };
     for (name in defaults) {
@@ -1480,7 +1489,7 @@ module.exports = {
     console.log(ewd.poolSize + ' child Node processes will be started...');
 
     // start child processes which, in turn, starts web server
-    ewd.startChildProcess(0);
+    ewd.startChildProcess(0, ewd.debug.enabled);
 
     if (callback) callback(ewd);
 


### PR DESCRIPTION
By adding a debug.enabled option in the ewdStart.js file, you can immediately launch your child processes in the node backend in debug mode (no need to restart them in the ewdMonitor). Also, when in debug mode, it reduces poolSize to 1.