### PR TITLE
Added support for optional before/after Request handler functions

### DIFF
--- a/lib/ewd.js
+++ b/lib/ewd.js
@@ -94,6 +94,7 @@ var ewd = {
         type: 'gtm',
       },
       debug: {
+      	enabled: false,
         child_port: 5859,
         web_port: 8081
       },
@@ -150,12 +151,23 @@ var ewd = {
     };
 
     if (params) {
+      if (!params.childProcess) params.childProcess = {};
+      if (params.poolSize) {
+        if (!params.childProcess.poolSize)
+          params.childProcess.poolSize = params.poolSize;
+      }
+      if (params.debug) {
+      	if (typeof params.debug.enabled !== 'undefined') {
+      	  defaults.debug.enabled = params.debug.enabled;
+      	  if (params.debug.enabled)
+      	    params.childProcess.poolSize = 1;
+      	}
+      }
       if (params.database) {
         if (typeof params.database.type !== 'undefined') defaults.database.type = params.database.type;
         if (params.database.type === 'noDB' || params.database.nodePath === 'noDB') {
           params.database.type = 'gtm';
           params.database.nodePath = 'noDB';
-          if (!params.childProcess) params.childProcess = {};
           params.childProcess.poolSize = 1;
           params.childProcess.maximum = 1;
           params.childProcess.auto = false;
@@ -194,12 +206,9 @@ var ewd = {
         port: 27017
       };
     }
-    if (defaults.poolSize && !defaults.childProcess.poolSize) defaults.childProcess.poolSize = defaults.poolSize;
-    if (params.childProcess) {
-      if (params.childProcess.poolSize) {
-        if (!params.childProcess.maximum && params.childProcess.poolSize > defaults.childProcess.maximum) {
-          params.childProcess.maximum = params.childProcess.poolSize;
-        }
+    if (params.childProcess.poolSize) {
+      if (!params.childProcess.maximum && params.childProcess.poolSize > defaults.childProcess.maximum) {
+        params.childProcess.maximum = params.childProcess.poolSize;
       }
     }
     this.setDefaults(defaults, params);
@@ -210,9 +219,11 @@ var ewd = {
     var subDefaults = {
       childProcess: '',
       database: '',
+      debug: '',
       https: '',
       webSockets: '',
       management: '',
+      ajax: '',
       webRTC: '',
       webservice: ''
     };
@@ -2725,7 +2736,7 @@ module.exports = {
     console.log(ewd.childProcess.poolSize + ' child Node processes will be started...');
 
     // start child processes which, in turn, starts web server
-    ewd.startChildProcess(0);
+    ewd.startChildProcess(0, ewd.debug.enabled);
 
     if (callback) callback(ewd);
 

--- a/lib/ewdChildProcess.js
+++ b/lib/ewdChildProcess.js
@@ -134,7 +134,8 @@ var EWD = {
       content: {
         sessid: sessid,
         appName: application,
-        expiry: new Date((expiry - 4070908800) * 1000).toUTCString()
+        //expiry: new Date((expiry - 4070908800) * 1000).toUTCString()
+        expiry: new Date(expiry * 1000).toUTCString()
       }
     });
 
@@ -785,7 +786,8 @@ var ewdChild = {
         content: {
           sessid: sessid,
           appName: application.name,
-          expiry: new Date((expiry - 4070908800) * 1000).toUTCString()
+          //expiry: new Date((expiry - 4070908800) * 1000).toUTCString()
+          expiry: new Date(expiry * 1000).toUTCString()
         }, 
         appName: 'ewdMonitor'
       });

--- a/lib/ewdChildProcess.js
+++ b/lib/ewdChildProcess.js
@@ -1084,11 +1084,14 @@ var ewdChild = {
         }
         var result;
         if (ewdChild.module[moduleName].onMessage && ewdChild.module[moduleName].onMessage[type]) {
-
           try {
+						if (ewdChild.module[moduleName].beforeOnMessage)
+							ewdChild.module[moduleName].beforeOnMessage(params);
             //if (ewdChild.timing) ewdChild.timing.beforeOnMessage = EWD.getElapsedMs(ewdChild.timing);   
             result =  ewdChild.module[moduleName].onMessage[type](messageObj.params, params) || '';
             //if (ewdChild.timing) ewdChild.timing.afterOnMessage = EWD.getElapsedMs(ewdChild.timing);   
+						if (ewdChild.module[moduleName].afterOnMessage)
+							result = ewdChild.module[moduleName].afterOnMessage(params, result);
             return {response: result};
           }
           catch(err) {
@@ -1100,7 +1103,11 @@ var ewdChild = {
         }
         else {
           if (ewdChild.module[moduleName].onSocketMessage) {
+						if (ewdChild.module[moduleName].beforeOnSocketMessage)
+							ewdChild.module[moduleName].beforeOnSocketMessage(params);
             result =  ewdChild.module[moduleName].onSocketMessage(params) || '';
+						if (ewdChild.module[moduleName].afterOnSocketMessage)
+							result = ewdChild.module[moduleName].afterOnSocketMessage(params, result);
             //return {pid: process.pid, response: result};
             return {response: result};
           }
@@ -1204,7 +1211,11 @@ var ewdChild = {
       try { 
         //console.log('invoking handler for ' + moduleName + ' / ' + serviceName + ' at ' + process.hrtime(ewdChild.startns));
         //if (ewdChild.timing) ewdChild.timing.push({invokingModuleService: process.hrtime(ewdChild.timing[0].start)});
+				if (ewdChild.module[moduleName][serviceName].beforeRequest)
+					ewdChild.module[moduleName][serviceName].beforeRequest(params);
         result = ewdChild.module[moduleName][serviceName](params) || '';
+				if (ewdChild.module[moduleName][serviceName].afterRequest)
+					result = ewdChild.module[moduleName][serviceName].afterRequest(params, result);
         //console.log('handler completed at ' + process.hrtime(ewdChild.startns));
         //if (ewdChild.timing) ewdChild.timing.push({moduleServiceCompleted: process.hrtime(ewdChild.timing[0].start)});
       }

--- a/modules/ewdMonitor.js
+++ b/modules/ewdMonitor.js
@@ -342,7 +342,8 @@ module.exports = {
         ewdSessions._forEach(function(sessid, session) {
           var appName = session.$('ewd_appName')._value;
           var expiry = session.$('ewd_sessionExpiry')._value;
-          expiry = (expiry - 4070908800) * 1000;
+          //expiry = (expiry - 4070908800) * 1000;
+          expiry = expiry * 1000;
           var expireDate = new Date(expiry);
           rowNo++;
           var currentSession = (sessid === mySessid);


### PR DESCRIPTION
You can define before/after message or request functions in a user module. These functions are called on every incoming message/request. Useful for call monitoring, params/result modifications, ...