### PR TITLE
Support for optional before/after message/request hooks

### DIFF
--- a/lib/ewdChildProcess.js
+++ b/lib/ewdChildProcess.js
@@ -1087,7 +1087,11 @@ var ewdChild = {
 
           try {
             //if (ewdChild.timing) ewdChild.timing.beforeOnMessage = EWD.getElapsedMs(ewdChild.timing);   
+            if (ewdChild.module[moduleName].beforeOnMessage)
+              ewdChild.module[moduleName].beforeOnMessage(params);
             result =  ewdChild.module[moduleName].onMessage[type](messageObj.params, params) || '';
+            if (ewdChild.module[moduleName].afterOnMessage)
+              result = ewdChild.module[moduleName].afterOnMessage(params, result);
             //if (ewdChild.timing) ewdChild.timing.afterOnMessage = EWD.getElapsedMs(ewdChild.timing);   
             return {response: result};
           }
@@ -1100,7 +1104,11 @@ var ewdChild = {
         }
         else {
           if (ewdChild.module[moduleName].onSocketMessage) {
+            if (ewdChild.module[moduleName].beforeOnSocketMessage)
+              ewdChild.module[moduleName].beforeOnSocketMessage(params);
             result =  ewdChild.module[moduleName].onSocketMessage(params) || '';
+            if (ewdChild.module[moduleName].afterOnSocketMessage)
+              result = ewdChild.module[moduleName].afterOnSocketMessage(params, result);
             //return {pid: process.pid, response: result};
             return {response: result};
           }
@@ -1204,7 +1212,11 @@ var ewdChild = {
       try { 
         //console.log('invoking handler for ' + moduleName + ' / ' + serviceName + ' at ' + process.hrtime(ewdChild.startns));
         //if (ewdChild.timing) ewdChild.timing.push({invokingModuleService: process.hrtime(ewdChild.timing[0].start)});
+        if (ewdChild.module[moduleName][serviceName].beforeRequest)
+          ewdChild.module[moduleName][serviceName].beforeRequest(params);
         result = ewdChild.module[moduleName][serviceName](params) || '';
+        if (ewdChild.module[moduleName][serviceName].afterRequest)
+          result = ewdChild.module[moduleName][serviceName].afterRequest(params, result);
         //console.log('handler completed at ' + process.hrtime(ewdChild.startns));
         //if (ewdChild.timing) ewdChild.timing.push({moduleServiceCompleted: process.hrtime(ewdChild.timing[0].start)});
       }


### PR DESCRIPTION
Now you can define a beforeOnMessage/afterOnMessage handler function hook in your back-end module.
These functions/hooks are called on every incoming message/request. Useful e.g. for back-end call monitoring, params/results modifications, ...