### PR TITLE
Expiry date correction

### DIFF
--- a/essentials/node_modules/ewdMonitor.js
+++ b/essentials/node_modules/ewdMonitor.js
@@ -476,16 +476,13 @@ module.exports = {
         ewdSessions._forEach(function(sessid, session) {
           var appName = session.$('ewd_appName')._value;
           var expiry = session.$('ewd_sessionExpiry')._value;
-          // thanks to Ward DeBacker for this bug-fix:
-          //expiry = (expiry - 4070908800) * 1000;
-          var expireDate = new Date(expiry * 1000);
           rowNo++;
           var currentSession = (sessid === mySessid);
           data.push({
             rowNo: rowNo, 
             sessid: sessid, 
             appName: appName, 
-            expiry: expireDate.toUTCString(), 
+            expiry: new Date((expiry - 4070908800) * 1000).toUTCString(),
             currentSession: currentSession
           });
         });

--- a/lib/ewdChildProcess.js
+++ b/lib/ewdChildProcess.js
@@ -107,7 +107,7 @@ var EWD = {
     token = null;
     sessid = null;
     if (expiry === '') return true;
-    var now = Math.floor(new Date().getTime()/1000);
+    var now = Math.floor(new Date().getTime()/1000) + 4070908800;
     //if (expiry > this.hSeconds()) return false;
     if (expiry > now) return false;
     return true;
@@ -119,7 +119,7 @@ var EWD = {
     database.kill(node);
 
     var token = EWD.createToken();
-    var now = Math.floor(new Date().getTime()/1000);
+    var now = Math.floor(new Date().getTime()/1000) + 4070908800;
     //var now = EWD.hSeconds();
     if (!timeout) timeout = 3600;
     var expiry = now + timeout;
@@ -141,9 +141,7 @@ var EWD = {
       content: {
         sessid: sessid,
         appName: application,
-        // thanks to Ward DeBacker for this bug-fix:
-        //expiry: new Date((expiry - 4070908800) * 1000).toUTCString()
-        expiry: new Date(expiry * 1000).toUTCString()
+        expiry: new Date((expiry - 4070908800) * 1000).toUTCString()
       }
     });
 
@@ -202,7 +200,7 @@ var EWD = {
   },
   updateSessionExpiry: function(session) {
     //var now = EWD.hSeconds();
-    var now = Math.floor(new Date().getTime()/1000);
+    var now = Math.floor(new Date().getTime()/1000) + 4070908800;
     var sessid = session.sessid;
     var timeout = +database.get({global: ewdChild.global.session, subscripts: ['session', sessid, 'ewd_sessionTimeout']}).data;
     var savedExpiry = database.get({global: ewdChild.global.session, subscripts: ['session', sessid, 'ewd_sessionExpiry']}).data;
@@ -234,7 +232,7 @@ var EWD = {
     var sessid;
     var expiryNode;
     var expiry;
-    var now = Math.floor(new Date().getTime()/1000);
+    var now = Math.floor(new Date().getTime()/1000) + 4070908800;
     do {
       node = database.order(node);
       sessid = node.result || '';
@@ -861,7 +859,7 @@ var ewdChild = {
 
       var token = EWD.createToken();
       //var now = EWD.hSeconds();
-      var now = Math.floor(new Date().getTime()/1000);
+      var now = Math.floor(new Date().getTime()/1000) + 4070908800;
       var timeout = messageObj.application.timeout || 3600;
       var expiry = now + timeout;
       var application = {name: 'undefined'};
@@ -889,9 +887,7 @@ var ewdChild = {
         content: {
           sessid: sessid,
           appName: application.name,
-          // thanks to Ward DeBacker for this bug-fix
-          //expiry: new Date((expiry - 4070908800) * 1000).toUTCString()
-          expiry: new Date(expiry * 1000).toUTCString()
+          expiry: new Date((expiry - 4070908800) * 1000).toUTCString()
         }, 
         appName: 'ewdMonitor'
       });


### PR DESCRIPTION
Keep ewd_sessionExpiry in $H seconds format (and stay compatible with EWD classic). This allows both EWD classic and EWD.js to coexist on the same server.