### PR TITLE
Correct time format for header function

### DIFF
--- a/lib/masterProcess/fileRequestHandler.js
+++ b/lib/masterProcess/fileRequestHandler.js
@@ -69,7 +69,7 @@ var fetchFile = function(fileName, request, response) {
               var etag = stat.size + '-' + Date.parse(stat.mtime);
               if (ewd.traceLevel >= 2) console.log("etag = " + etag);
               if (request.headers['if-none-match'] === etag) {
-                response.setHeader('Last-Modified', stat.mtime);
+                response.setHeader('Last-Modified', stat.mtime.toUTCString());
                 response.statusCode = 304;
                 response.end();
                 return;


### PR DESCRIPTION
The absence of a method (toUTCString) generates an error and stopping the EWD on the cyrillic systems, that are in the output stat.mtime invalid characters.