### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/childProcess/EWD.js
+++ b/lib/childProcess/EWD.js
@@ -29,7 +29,7 @@
 
 var fs = require('fs');
 var events = require('events');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var se = require('speakeasy');
 var ntp = require('ntp-client');
 

--- a/package.json
+++ b/package.json
@@ -21,16 +21,16 @@
     "node": ">=0.2.2"
   },
   "dependencies": {
-    "socket.io": ">=0.9.6",
-    "globalsjs": ">=0.20.0",
-    "fast-url-parser": ">=1.0.6-0",
-    "mime": ">=1.2.11",
     "ewdliteclient": ">=0.4.0",
-    "node-uuid": ">=1.4.2",
-    "ntp-client": ">=0.5.3",
-    "speakeasy": ">=1.0.3",
+    "fast-url-parser": ">=1.0.6-0",
+    "globalsjs": ">=0.20.0",
     "graceful-fs": ">=3.0.5",
-    "request": ">=2.65.0"
+    "mime": ">=1.2.11",
+    "ntp-client": ">=0.5.3",
+    "request": ">=2.65.0",
+    "socket.io": ">=0.9.6",
+    "speakeasy": ">=1.0.3",
+    "uuid": "^3.0.0"
   },
   "licenses": [
     "Apache"


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.